### PR TITLE
Change base URL for production site to kbhff.dk

### DIFF
--- a/ci/CodeIgniter-2.2.6/application/config/config.php
+++ b/ci/CodeIgniter-2.2.6/application/config/config.php
@@ -35,7 +35,7 @@ define('FF_ANNUALFEE', 77);
 */
 
 if(ENVIRONMENT == "production") {
-	$config['base_url']	= 'http://website.kbhff.dk';
+	$config['base_url']	= 'http://kbhff.dk';
 }
 else if(ENVIRONMENT == "testing") {
 	$config['base_url']	= 'http://test.kbhff.dk';


### PR DESCRIPTION
This prevents automatic redirection to the `website.` subdomain.