### PR TITLE
Implement sindexBase on weeklybag item type

### DIFF
--- a/theme/classes/items/type.weeklybag.class.php
+++ b/theme/classes/items/type.weeklybag.class.php
@@ -144,6 +144,12 @@ class TypeWeeklybag extends Itemtype {
 		return false;
 
 	}
+
+	function sindexBase($item_id){
+		return sprintf("pose-%04d-uge-%02d",
+			$this->getProperty("year", "value"),
+			$this->getProperty("week", "value"));
+	}
 }
 
 ?>


### PR DESCRIPTION
This is intended to solve [https://trello.com/c/8hwqEqrQ/253-jc-website-url-of-ugens-pose-to-rename-automatically](https://trello.com/c/8hwqEqrQ/253-jc-website-url-of-ugens-pose-to-rename-automatically)

This implements the method `sindexBase` for the weeklybag item type. The format is `pose-YYYY-uge-WW`. I will open a pull request for the janitor repository that uses this method to update the sindex when the bag is updated.