### PR TITLE
Update wording of mobilepay checkout

### DIFF
--- a/theme/templates/member-help/payment.php
+++ b/theme/templates/member-help/payment.php
@@ -213,7 +213,7 @@ else {
 					<h5>MobilePay-nummer</h5>
 					<p>(<?=$department["name"]?>)</p>
 					<p class="payment_info"><span class="highlight"><?=$department["mobilepay_id"]?></span></p>
-					<h5>Medlemsoprettelseskode</h5>
+					<h5>Betalingsreference</h5>
 					<p>(Skrives i kommentarfeltet)</p>
 					<p class="payment_info"><span class="highlight"><?=$transaction_id?></span></p>
 				</div>


### PR DESCRIPTION
Replace "Medlemsoprettelseskode" with "Betalingsreference" as requested by the text writing group.