### PR TITLE
Fix double quotes in link in deactivation_notice email

### DIFF
--- a/theme/templates/mails/deactivation_notice.html
+++ b/theme/templates/mails/deactivation_notice.html
@@ -95,7 +95,7 @@
 				In one week it will be time to pay the yearly subscription to Københavns Fødevarefællesskab. After this it will not be possible for you to order until you have renewed your membership. You will still be able to see existing orders.
 			</p>
 			<p style="font-family: Arial, sans-serif; font-size: 15px; color: #000000; padding: 0; margin: 30px 0 15px;">
-				Instead of paying it manually you can sign up for automatic renewal on <a href=”medlem.kbhff.dk”>Min Side</a>. Then your membership will be automatically charged next week and for each following annual renewal.
+				Instead of paying it manually you can sign up for automatic renewal on <a href="medlem.kbhff.dk">Min Side</a>. Then your membership will be automatically charged next week and for each following annual renewal.
 			</p>
 			<p style="font-family: Arial, sans-serif; font-size: 15px; color: #000000; padding: 0; margin: 30px 0 30px;">
 				Alternatively, you can log on after {EXPIRES_AT} and pay your membership fee manually. You can also renew your membership in your department instead of doing it online.


### PR DESCRIPTION
Somehow the character ” ended up in the anchor tag rather than ", which caused the link to display strangely.